### PR TITLE
Fixing audio recording example table

### DIFF
--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -1809,8 +1809,8 @@ If it's a possibility that an individual question could need different qualities
 
   select_one, yes_no, is_quiet, Are you currently in a quiet location with only one person speaking at a time?
 
-  audio recording_voice_only, Please record, quality='voice-only',, ${is_quiet} = 'yes'
-  audio recording_normal, Please record, quality='normal',, ${is_quiet} = 'no'
+  audio, recording_voice_only, Please record, quality='voice-only', ${is_quiet} = 'yes'
+  audio, recording_normal, Please record, quality='normal', ${is_quiet} = 'no'
 
 .. csv-table:: choices
   :header: list_name, name, label

--- a/src/form-question-types.rst
+++ b/src/form-question-types.rst
@@ -1807,7 +1807,7 @@ If it's a possibility that an individual question could need different qualities
 .. csv-table:: survey
   :header: type, name, label, parameters, relevance
 
-  select_one, yes_no, is_quiet, Are you currently in a quiet location with only one person speaking at a time?
+  select_one yes_no, is_quiet, Are you currently in a quiet location with only one person speaking at a time?
 
   audio, recording_voice_only, Please record, quality='voice-only', ${is_quiet} = 'yes'
   audio, recording_normal, Please record, quality='normal', ${is_quiet} = 'no'


### PR DESCRIPTION
Fixed typos in the markdown example table for internal audio questions which merged the question type and name columns and put the parameters into the label column.
